### PR TITLE
Deploy Uptime Kuma container for website monitoring

### DIFF
--- a/containers.yml
+++ b/containers.yml
@@ -41,3 +41,6 @@
     - name: Deploy Backup Script for arr stack
       ansible.builtin.import_tasks: tasks/ubuntu/backup/arr_backup.yml
       tags: ['backup']
+    - name: Deploy Uptime Kuma Container
+      ansible.builtin.import_tasks: tasks/docker-containers/uptime-kuma/main.yml
+      tags: ['uptime_kuma']

--- a/tasks/docker-containers/homepage/templates/services.yaml.j2
+++ b/tasks/docker-containers/homepage/templates/services.yaml.j2
@@ -19,6 +19,14 @@
         widget:
           type: pialert
           url: http://homelab1.jalexmatey.co.uk:20211
+    - Uptime Kuma:
+        icon: uptime-kuma.png
+        href: http://homelab1.jalexmatey.co.uk:3001/
+        description: Website monitoring
+        widget:
+          type: uptimekuma
+          url: http://homelab1.jalexmatey.co.uk:3001
+          slug: live
 
 - Media:
     - jellyfin:

--- a/tasks/docker-containers/uptime-kuma/main.yml
+++ b/tasks/docker-containers/uptime-kuma/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Deploy uptime-kuma container.
+  community.docker.docker_container:
+    name: uptime-kuma
+    image: louislam/uptime-kuma:1
+    ports:
+      - "3001:3001/tcp"
+    volumes:
+      - '{{ uptimekuma_path }}:/app/data'
+    network_mode: "{{ docker_network }}"
+    restart_policy: unless-stopped

--- a/vars/docker_container_vars.yml
+++ b/vars/docker_container_vars.yml
@@ -7,6 +7,7 @@ qbittorent_path: ./qbittorent-config
 jackett_path: ./jackett-data
 sonarr_path: "/home/{{ username }}/sonarr-data"
 pialert_path: "/home/{{ username }}/pialert"
+uptimekuma_path: "/home/{{ username }}/uptime-kuma"
 
 ### MISC
 render_id: "109" # Result of `getent group render | cut -d: -f3` on the host


### PR DESCRIPTION
Deploys a Uptime Kuma container using docker and ansible. This also adds an Uptime Kuma shortcut to Homepage and implements the widget option (shows up, down, uptime) on Homepage itself.

Closes #13 